### PR TITLE
Use specified ubuntu base image, write context path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:trusty
 MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \

--- a/apply-from-env.php
+++ b/apply-from-env.php
@@ -96,7 +96,7 @@ foreach ($servers as $name => $url) {
 
     # proxy for ' . $name . '
     location /' . $name . '/ {
-        proxy_pass ' . $url . ';
+        proxy_pass ' . $url . ' . '/' . ' . $name . '/;
 
         # rewrite redirect / location headers to match this subdir
         proxy_redirect default;


### PR DESCRIPTION
Current "ubuntu" base image does not have the php5-cli package.
Also, it is generally a good pattern to use a context path for each proxied application.

Like, if we have two apps, one of them can be localhost:80/app1, and the other can be localhost:80/app2.